### PR TITLE
fix test_layer_normalization.py

### DIFF
--- a/tests/test_layer_normalization.py
+++ b/tests/test_layer_normalization.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import unittest
 import numpy as np
+import tensorflow as tf
 from keras_multi_head import MultiHeadAttention
 from keras_layer_normalization.backend import keras
 from keras_layer_normalization import LayerNormalization
@@ -89,7 +90,7 @@ class TestLayerNormalization(unittest.TestCase):
             outputs=dense_layer,
         )
         model.compile(
-            optimizer=keras.optimizers.Adam(lr=1e-3),
+            optimizer=tf.keras.optimizers.Adam(lr=1e-3),
             loss='mse',
             metrics={},
         )
@@ -153,7 +154,7 @@ class TestLayerNormalization(unittest.TestCase):
             outputs=dense_layer,
         )
         model.compile(
-            optimizer=keras.optimizers.Adam(lr=1e-3),
+            optimizer=tf.keras.optimizers.Adam(lr=1e-3),
             loss='mse',
             metrics={},
         )


### PR DESCRIPTION
This PR aims to fix flaky test `tests/test_layer_normalization.py`. It is flaky depending on the version of python, and the original usage `keras.optimizers.Adam(lr=1e-3)` is no longer valid in python 3.7. We can replace it with `tf.keras.optimizers.Adam(lr=1e-3)`.
The error can be reproduced by `pytest`.